### PR TITLE
Remove duplicate entry Frontend United (Ghent, May 2016)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@ A list of 2016 web development conferences.
 
 ## Contributing 
 1. Fork it
-2. Add your conference to `list.json`
-3. Create your feature branch (`git checkout -b my-new-feature`)
-4. Commit your changes (`git commit -am "Add some feature"`)
-5. Push to the branch (`git push origin my-new-feature`)
-6. Create new Pull Request
+2. Run `npm install`
+3. Add your conference to `list.json`
+4. Run `node index` to update `README.md` with your changes
+5. Create your feature branch (`git checkout -b my-new-feature`)
+6. Commit your changes (`git commit -am "Add some feature"`)
+7. Push to the branch (`git push origin my-new-feature`)
+8. Create new Pull Request
 
 #Conference List
 
@@ -717,12 +719,6 @@ A list of 2016 web development conferences.
 **Where:** Manchester, UK
 
 **When:** May 27, 2016
-
-
-## [Frontend United 2016](http://frontendunited.org/)
-**Where:** Ghent, Belgium
-
-**When:** May 27–28, 2016
 
 
 ## [Sud Web 2016](http://sudweb.fr/)

--- a/list.json
+++ b/list.json
@@ -827,13 +827,6 @@
     "month": "May"
   },
   {
-    "title": "Frontend United 2016",
-    "url": "http://frontendunited.org/",
-    "where": "Ghent, Belgium",
-    "when": "May 27–28, 2016",
-    "month": "May"
-  },
-  {
     "title": "Sud Web 2016",
     "url": "http://sudweb.fr/",
     "where": "Bordeaux, France",


### PR DESCRIPTION
"Frontend United" and "Frontend United 2016" are the same conference, deleted one of them.
